### PR TITLE
Fixes for PR #9

### DIFF
--- a/src/com/geeksong/agricolascorer/FinishedActivity.java
+++ b/src/com/geeksong/agricolascorer/FinishedActivity.java
@@ -236,6 +236,8 @@ public class FinishedActivity extends Activity {
 
         public static final int[] SCORE_LABEL_IDS = new int[AgricolaHandler.SCORE_LABEL_IDS.length + 2];
         static {
+            System.arraycopy(AgricolaHandler.SCORE_LABEL_IDS, 0, SCORE_LABEL_IDS, 0,
+                    AgricolaHandler.SCORE_LABEL_IDS.length);
             SCORE_LABEL_IDS[AgricolaHandler.SCORE_LABEL_IDS.length] = R.string.horses_label;
             SCORE_LABEL_IDS[AgricolaHandler.SCORE_LABEL_IDS.length + 1] = R.string.in_bed_family_label;
         }


### PR DESCRIPTION
- Added SuppressWarnings for Eclipse warnings about generics. NB: I could have avoided generics here, but it avoids ugly casts. Base problem is that GameType management is not using generics outside this class
- the FC bug was a silly code bug specific to Farmers game

Sylvain
